### PR TITLE
v0.2.0: ATProto spec compliance and self-hosted PDS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,29 @@
 
 ![Demo of ByeSky in action](media/byesky_demo.gif)
 
-ByeSky is a CLI tool to delete BlueSky posts older than a specified number of days, with advanced filtering, backup, preview and automation options.
+ByeSky is a CLI tool to delete Bluesky / AT Protocol posts older than a specified number of days, with advanced filtering, backup, preview, and automation options.
+
+Supports both **Bluesky (bsky.social)** and **self-hosted PDS** instances.
 
 ## Motivation
 
-I believe that opinions change, trends fade, and not every thought or post needs to live online forever. As someone who values privacy, I wanted a tool that empowers users to easily and safely clean up their BlueSky history giving them control over what remains public. ByeSky is designed to make it simple to review, filter, and remove old posts.
+Opinions change, trends fade, and not every thought needs to live online forever. ByeSky gives you control over your post history — safely preview what would be deleted, then remove it.
 
 ## Features
 
-- Export logs
-- Verbose and quiet modes
-- Cron job friendly
-- Advanced filtering (date, keyword, regex, replies, reposts)
-- Backup deleted posts
+- **AT Protocol spec-compliant** — uses `com.atproto.repo.listRecords` and `com.atproto.repo.deleteRecord` directly, no AppView dependency
+- **Self-hosted PDS support** — point `--pds` at any AT Protocol PDS
+- **Preview mode** — see exactly what would be deleted before committing
+- **Advanced filtering** — by age, date range, keyword, regex, replies, and native reposts
+- **Backup** — every deleted post is saved to a JSONL file before removal
+- **Rate-limit aware** — configurable delay between deletions
+- **Automation-friendly** — quiet mode, env-var auth, non-zero exit codes
+- **Verbose and quiet modes**
+- **Cron-job friendly**
 
 ## Disclaimer
 
-**Warning:** This tool performs irreversible data deletion. Use with caution.  
-Double-check your filters and options before running by using `--preview`.  
-
-**The `--preview` option will only show what would be deleted and will NOT delete any posts.**  
-
-**The `--no-preview` option will actually delete the matching posts.**  
+**Warning:** Deletion is irreversible. Always run with `--preview` first and review the log before using `--no-preview`.
 
 The author is **not responsible** for any data loss or unintended consequences.
 
@@ -35,59 +36,47 @@ The author is **not responsible** for any data loss or unintended consequences.
     cd ByeSky
     ```
 
-2. [Create a BlueSky app password](https://bsky.app/settings/app-passwords).
+2. [Create a Bluesky app password](https://bsky.app/settings/app-passwords).
 
 ### Option 1: Virtual Environment (Recommended)
 
 ```zsh
-# Create a virtual environment
 python3 -m venv venv
-
-# Activate the virtual environment
 source venv/bin/activate
-
-# Install dependencies
 pip install -r requirements.txt
-
-# Run ByeSky (make sure venv is activated)
 python byesky.py --handle yourhandle.bsky.social --days 30 --preview
 ```
 
-### Option 2: Using pipx (macOS-friendly)
+### Option 2: pipx (macOS-friendly, installs globally without conflicts)
 
 ```zsh
-# Install pipx (if not already installed)
 brew install pipx
-
-# Install ByeSky globally with pipx
 pipx install .
-
-# Run ByeSky
 byesky --handle yourhandle.bsky.social --days 30 --preview
 ```
 
-### Option 3: Direct Installation (Not Recommended)
+### Option 3: Direct (not recommended)
 
 ```zsh
-# Install dependencies globally (may cause conflicts)
 pip3 install -r requirements.txt --break-system-packages
 ```
 
-> **Note:**  
-> ByeSky is compatible with Pydantic v2 and newer.  
-> If you see errors about `.dict()`, upgrade Pydantic:  
-> `pip install --upgrade pydantic`  
-> Requires Python 3.8 or newer (recommended).
+> Requires Python 3.8+. Compatible with Pydantic v2+.
 
 ## Quick Start
 
 ```zsh
-python3 byesky.py --handle johnappleseed@bsky.social --days 30 --preview
+# Preview posts older than 30 days (default — nothing is deleted)
+python3 byesky.py --handle alice.bsky.social --days 30 --preview
+
+# Actually delete them
+python3 byesky.py --handle alice.bsky.social --days 30 --no-preview
+
+# Self-hosted PDS
+python3 byesky.py --handle alice.example.com --pds https://pds.example.com --days 30 --preview
 ```
 
-- By default, this will **preview** posts older than 30 days.
-- To actually delete, add `--no-preview`.
-- You will be prompted for your app password, or set it via the `BYESKY_TOKEN` environment variable.
+You will be prompted for your app password, or set it via `BYESKY_TOKEN`.
 
 ## Usage
 
@@ -95,232 +84,165 @@ python3 byesky.py --handle johnappleseed@bsky.social --days 30 --preview
 python3 byesky.py [OPTIONS]
 ```
 
-### Required
-
-- `--handle`, `-u`  
-  Your BlueSky handle (e.g., `johnappleseed@bsky.social`).
-
 ### Authentication
 
-- `--token`, `-p`  
-  Your BlueSky app password (16 chars). If omitted, you will be prompted.
-  **Tip:** For automation, set the `BYESKY_TOKEN` environment variable.
+| Option | Description |
+|--------|-------------|
+| `--handle`, `-u` | Your AT Protocol handle (e.g. `alice.bsky.social`) |
+| `--token`, `-p` | App password — reads `BYESKY_TOKEN` env var if not provided, then prompts |
 
-### Age Filtering
+**Tip:** For automation, set `BYESKY_TOKEN` in your environment instead of using `--token`.
 
-- `--days`, `-d`  
-  Delete posts older than this many days.  
-  Example:  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --days 60 --preview
-  ```
+### PDS / Server
 
-### Preview Mode
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--pds` | `https://bsky.social` | AT Protocol PDS base URL |
 
-- `--preview/--no-preview`  
-  Only show what would be deleted, do not actually delete.  
-  Default: `--preview`  
-  Example:  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --days 30 --preview
-  ```
+For a self-hosted PDS, set `--pds https://your-pds.example.com`. Your handle and app password are resolved against that PDS.
 
-### Logging
+### Filtering
 
-- `--log-file`, `-l`  
-  Override log file name.  
-  Example:  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --days 30 --log-file mylog.txt
-  ```
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--days`, `-d` | `30` | Target posts older than this many days |
+| `--after DATE` | — | Only target posts on or after this date (YYYY-MM-DD or ISO 8601) |
+| `--before DATE` | — | Only target posts on or before this date |
+| `--match`, `-m` | — | Only target posts containing this keyword (repeatable) |
+| `--regex/--no-regex` | off | Treat `--match` values as regular expressions |
+| `--include-replies/--exclude-replies` | exclude | Include reply posts |
+| `--include-reposts/--exclude-reposts` | exclude | Include native reposts (`app.bsky.feed.repost` records) |
 
-### Keyword/Regex Filtering
+### Preview & Safety
 
-- `--match`, `-m`  
-  Only delete posts containing this keyword or matching regex. Can be used multiple times.  
-  Example (keyword):  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --days 30 --match hello --match world
-  ```
-  Example (regex):  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --days 30 --match '^foo.*bar$' --regex
-  ```
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--preview/--no-preview` | `--preview` | Dry run — show what would be deleted without deleting |
 
-- `--regex/--no-regex`  
-  Interpret `--match` patterns as regex.  
-  Example:  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --days 30 --match 'test\d+' --regex
-  ```
+**Always preview first.** Deletion is permanent.
 
-### Date Range Filtering
+### Output & Logging
 
-- `--after`  
-  Only consider posts after this date (inclusive).  
-  Example:  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --after 2024-01-01 --preview
-  ```
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--log-file`, `-l` | auto | Log filename (default: `preview_log.txt` or `deleted_posts_log.txt`) |
+| `--backup-file` | `deleted_posts_backup.jsonl` | JSONL file for deleted-post backups |
+| `--verbose` | off | Enable DEBUG logging |
+| `--quiet` | off | Suppress all output except errors and the final summary |
 
-- `--before`  
-  Only consider posts before this date (inclusive).  
-  Example:  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --before 2024-06-01 --preview
-  ```
+### Rate Limiting
 
-### Backup
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--delete-delay` | `0.5` | Seconds between deletions (rate-limit buffer) |
 
-- `--backup-file`  
-  Backup deleted posts to this JSONL file (default: `deleted_posts_backup.jsonl`).  
-  Example:  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --no-preview --backup-file my_backup.jsonl
-  ```
+Bluesky's write rate limits are roughly 1,666 requests per 5 minutes. The default 0.5 s delay (~120 deletes/min) stays safely within that.
 
-### Replies and Reposts
-
-- `--include-replies/--exclude-replies`  
-  Include or exclude replies (default: exclude).  
-  Example:  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --preview --include-replies
-  ```
-
-- `--include-reposts/--exclude-reposts`  
-  Include or exclude reposts (default: exclude).  
-  Example:  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --no-preview --include-reposts
-  ```
-
-### Output Modes
-
-- `--verbose`  
-  Enable verbose output (DEBUG logging, show HTTP requests).  
-  Example:  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --preview --verbose
-  ```
-
-- `--quiet`  
-  Suppress most output except errors and summary.  
-  Progress bars are still shown in quiet mode.  
-  HTTP request logs are suppressed in quiet mode.  
-  Example:  
-  ```
-  python3 byesky.py --handle johnappleseed@bsky.social --no-preview --quiet
-  ```
-
-### Example: Delete posts older than 6 months (for cron job)
+## Examples
 
 ```zsh
-python3 byesky.py --handle johnappleseed@bsky.social --token YOUR_APP_PASSWORD --no-preview --days 180 --quiet
+# Preview posts older than 6 months
+python3 byesky.py --handle alice.bsky.social --days 180 --preview
+
+# Delete posts older than 30 days (cron-friendly, token via env var)
+BYESKY_TOKEN=xxxx-xxxx-xxxx-xxxx \
+  python3 byesky.py --handle alice.bsky.social --days 30 --no-preview --quiet
+
+# Delete posts matching a keyword, including replies, with backup
+python3 byesky.py --handle alice.bsky.social --no-preview \
+  --match "old opinion" --include-replies --backup-file backup.jsonl
+
+# Regex filter: posts starting with "hot take"
+python3 byesky.py --handle alice.bsky.social --preview \
+  --match '^hot take' --regex
+
+# Delete posts in a date range
+python3 byesky.py --handle alice.bsky.social --no-preview \
+  --after 2024-01-01 --before 2024-06-30
+
+# Self-hosted PDS
+python3 byesky.py --handle alice.example.com \
+  --pds https://pds.example.com --days 30 --preview
 ```
 
-### Example: Delete posts after a certain date, including replies, with backup
+## Self-Hosted PDS
+
+If you run your own AT Protocol PDS, pass its base URL with `--pds`:
 
 ```zsh
-python3 byesky.py --handle johnappleseed@bsky.social --no-preview --after 2024-01-01 --include-replies --backup-file backup.jsonl
+python3 byesky.py \
+  --handle alice.example.com \
+  --pds https://pds.example.com \
+  --days 30 \
+  --preview
 ```
+
+ByeSky communicates directly with your PDS using the `com.atproto.repo.*` lexicons, so it does not depend on Bluesky's AppView or any Bluesky-specific infrastructure.
+
+## How It Works
+
+ByeSky uses the AT Protocol lexicons directly:
+
+| Operation | Lexicon |
+|-----------|---------|
+| Authentication | `com.atproto.server.createSession` |
+| Listing posts | `com.atproto.repo.listRecords` (`app.bsky.feed.post`) |
+| Listing reposts | `com.atproto.repo.listRecords` (`app.bsky.feed.repost`) |
+| Deleting | `com.atproto.repo.deleteRecord` |
+
+All repository operations use your DID (resolved at login) rather than your handle, which is the spec-correct identifier for repo operations.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | One or more deletions failed |
+| `2` | Safety check failed (e.g. `--days 0` with `--no-preview`) or login failed |
+| `3` | File I/O error |
+| `99` | Unexpected error |
 
 ## Troubleshooting
 
-### Error: `'NoneType' object is not callable`
+### Login fails
 
-This error typically occurs due to one of these issues:
+- Confirm you are using an **app password**, not your main Bluesky password.
+- For self-hosted PDS: verify the `--pds` URL is correct and reachable.
+- Run with `--verbose` to see the full HTTP exchange.
 
-#### 1. **Virtual Environment Not Activated**
-If you're not using a virtual environment, you need to activate it first:
+### `'NoneType' object is not callable` / Pydantic errors
 
-```bash
-# Make sure you're in the ByeSky directory
-cd /path/to/ByeSky
-
-# Activate the virtual environment
+```zsh
 source venv/bin/activate
-
-# You should see (venv) at the start of your prompt
-# Then run the script
-python byesky.py --handle yourhandle.bsky.social --days 30 --preview
+pip install --upgrade pydantic atproto
 ```
 
-#### 2. **Pydantic Version Compatibility**
-The most likely cause is an outdated Pydantic version:
+### Missing dependencies
 
-```bash
-# Make sure virtual environment is activated
+```zsh
 source venv/bin/activate
-
-# Upgrade Pydantic
-pip install --upgrade pydantic
-
-# Try again
-python byesky.py --handle johnappleseed@bsky.social --days 30 --preview
-```
-
-#### 3. **Missing Dependencies**
-Some required packages might not be installed properly:
-
-```bash
-# Make sure virtual environment is activated
-source venv/bin/activate
-
-# Reinstall dependencies
 pip install -r requirements.txt
 ```
 
-#### 4. **macOS Python Environment Issues**
-macOS has an externally managed Python environment. If you don't have a virtual environment:
+### macOS externally managed Python
 
-```bash
-# Create a virtual environment
+```zsh
 python3 -m venv venv
-
-# Activate it
 source venv/bin/activate
-
-# Install dependencies
 pip install -r requirements.txt
-
-# Test the script
 python byesky.py --help
 ```
 
-#### 5. **Additional Debugging**
-If the error persists:
+### Too many deletion failures
 
-- Run with `--verbose` flag to get more detailed error information:
-  ```bash
-  python byesky.py --handle johnappleseed@bsky.social --days 30 --preview --verbose
-  ```
-- Check if you can access your BlueSky account normally
-- Try with a different handle or app password
-- Try with a smaller date range first:
-  ```bash
-  python byesky.py --handle johnappleseed@bsky.social --days 1 --preview
-  ```
-
-### Check Your Setup
-Run these commands to verify your environment:
-
-```bash
-# Check Python version
-python3 --version
-
-# Check if you're in a virtual environment
-echo $VIRTUAL_ENV
-
-# Check if you have a venv folder
-ls -la | grep venv
-```
+Lower `--delete-delay` or increase it if you're hitting rate limits. Failures are retried up to 5 times with exponential back-off.
 
 ## Security
 
-- Use an app password, not your main BlueSky password.
-- Consider using environment variables or a secrets manager for automation.
+- Use an **app password**, not your main password.
+- Store the token in `BYESKY_TOKEN` or a secrets manager — never hard-code it.
+- ByeSky never prints your token; it is masked in all log output.
 
 ## License
 
-MIT
+MIT — Copyright 2025 Brian Pierini

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ Opinions change, trends fade, and not every thought needs to live online forever
 - **Verbose and quiet modes**
 - **Cron-job friendly**
 
+## What's New in v0.2.0
+
+- **Self-hosted PDS support** via `--pds` — works with any AT Protocol-compliant server
+- **Spec-compliant API** — switched from `app.bsky.feed.getAuthorFeed` to `com.atproto.repo.listRecords`, removing the AppView dependency
+- **DID-based operations** — all repo calls now use your DID (resolved at login) instead of your handle
+- **Fixed repost detection** — native reposts are fetched from the `app.bsky.feed.repost` collection; previously only embedded reposts were checked
+- **Fixed reply detection** — checks the `reply` field on raw record values rather than the feed view
+- **Rate-limit buffer** — configurable `--delete-delay` (default 0.5 s) between deletions
+- **Improved retry logic** — 5 attempts with 2–60 s exponential back-off (up from 3 attempts)
+- **Accurate scan count** — counts every record scanned rather than estimating from page count
+
 ## Disclaimer
 
 **Warning:** Deletion is irreversible. Always run with `--preview` first and review the log before using `--no-preview`.
@@ -77,6 +88,13 @@ python3 byesky.py --handle alice.example.com --pds https://pds.example.com --day
 ```
 
 You will be prompted for your app password, or set it via `BYESKY_TOKEN`.
+
+> **zsh tip:** Always quote the `--pds` URL to prevent zsh from interpreting `://` as a glob:
+> ```zsh
+> python3 byesky.py --handle alice.example.com --pds "https://pds.example.com" --days 30 --preview
+> ```
+
+> **Custom domain handles:** If your handle is a custom domain (e.g. `alice.example.com` rather than `alice.bsky.social`), ByeSky resolves it to your DID automatically — just pass the handle as-is.
 
 ## Usage
 
@@ -172,12 +190,45 @@ If you run your own AT Protocol PDS, pass its base URL with `--pds`:
 ```zsh
 python3 byesky.py \
   --handle alice.example.com \
-  --pds https://pds.example.com \
+  --pds "https://pds.example.com" \
   --days 30 \
   --preview
 ```
 
-ByeSky communicates directly with your PDS using the `com.atproto.repo.*` lexicons, so it does not depend on Bluesky's AppView or any Bluesky-specific infrastructure.
+ByeSky communicates directly with your PDS using the `com.atproto.repo.*` lexicons — no dependency on Bluesky's AppView or any Bluesky-specific infrastructure.
+
+### Finding your PDS URL
+
+If you're not sure what your PDS URL is, you can look it up from your handle:
+
+```zsh
+# Step 1 — resolve your handle to a DID
+curl -s "https://bsky.social/xrpc/com.atproto.identity.resolveHandle?handle=alice.example.com"
+
+# Step 2 — look up the DID document to find your PDS serviceEndpoint
+curl -s "https://plc.directory/<your-did>" | python3 -m json.tool
+```
+
+Look for `"serviceEndpoint"` under `"#atproto_pds"` in the DID document — that is your PDS URL.
+
+### App passwords on self-hosted PDS
+
+You need an app password from your PDS, separate from any Bluesky app passwords. Check your PDS's settings or account page. If your PDS does not expose an app password UI, you can create one via the API:
+
+```zsh
+# Get an access token
+curl -s -X POST "https://pds.example.com/xrpc/com.atproto.server.createSession" \
+  -H "Content-Type: application/json" \
+  -d '{"identifier":"alice.example.com","password":"YOUR_PASSWORD"}' \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['accessJwt'])"
+
+# Create an app password
+curl -s -X POST "https://pds.example.com/xrpc/com.atproto.server.createAppPassword" \
+  -H "Authorization: Bearer <accessJwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"byesky"}' \
+  | python3 -m json.tool
+```
 
 ## How It Works
 
@@ -241,7 +292,7 @@ Lower `--delete-delay` or increase it if you're hitting rate limits. Failures ar
 
 - Use an **app password**, not your main password.
 - Store the token in `BYESKY_TOKEN` or a secrets manager — never hard-code it.
-- ByeSky never prints your token; it is masked in all log output.
+- ByeSky never prints or logs your token.
 
 ## License
 

--- a/byesky.py
+++ b/byesky.py
@@ -1,155 +1,211 @@
+#!/usr/bin/env python3
+"""
+ByeSky - Delete or preview AT Protocol / Bluesky posts older than N days.
+Supports both Bluesky (bsky.social) and self-hosted PDS instances.
+"""
+
 import os
 import sys
 import logging
 import getpass
 import re
 import json
+import time
 from datetime import datetime, timedelta, timezone
+from typing import List, Optional, Tuple
 
 import click
 from tqdm import tqdm
-from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
-from dateutil import parser
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+from dateutil import parser as dateutil_parser
 from atproto import Client, models
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
-# ─── Logging Setup ───────────────────────────────────────────────────────────────
+BSKY_PDS = "https://bsky.social"
+DELETE_DELAY = 0.5  # seconds between deletes — stays within Bluesky rate limits
+
+# ─── Logging ─────────────────────────────────────────────────────────────────
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[logging.StreamHandler(sys.stdout)]
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 logger = logging.getLogger(__name__)
 
-# ─── Security Checks ─────────────────────────────────────────────────────────────
-if os.geteuid() == 0:
-    logger.warning("It is not recommended to run this script as root.")
+# ─── Security ────────────────────────────────────────────────────────────────
+if os.name != "nt" and os.geteuid() == 0:
+    logger.warning("Running as root is not recommended.")
 
-# ─── Retry Decorator ─────────────────────────────────────────────────────────────
-retry_on_network = retry(
-    stop=stop_after_attempt(3),
-    wait=wait_exponential(multiplier=1, min=1, max=10),
+# ─── Retry ───────────────────────────────────────────────────────────────────
+_network_retry = retry(
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=2, min=2, max=60),
     retry=retry_if_exception_type(Exception),
-    reraise=True
+    reraise=True,
 )
 
-# ─── Core Logic ────────────────────────────────────────────────────────────────
-@retry_on_network
-def fetch_feed_page(client, actor, cursor, limit):
-    return client.app.bsky.feed.get_author_feed({
-        "actor": actor,
-        "cursor": cursor,
-        "limit": limit
-    })
 
-@retry_on_network
-def delete_record(client, handle, uri):
-    rkey = uri.split("/")[-1]
-    return client.com.atproto.repo.delete_record(models.ComAtprotoRepoDeleteRecord.Data(
-        repo=handle,
-        collection="app.bsky.feed.post",
-        rkey=rkey
-    ))
-
-def process_posts(
-    handle, token, days_old, preview_only, log_file,
-    match_patterns=None, use_regex=False, after=None, before=None, backup_file=None,
-    include_replies=False, include_reposts=False,
-    quiet=False
+@_network_retry
+def _list_records(
+    client: Client,
+    did: str,
+    collection: str,
+    cursor: Optional[str],
+    limit: int = 100,
 ):
-    client = Client()
+    """One page via com.atproto.repo.listRecords."""
+    params: dict = {"repo": did, "collection": collection, "limit": limit}
+    if cursor:
+        params["cursor"] = cursor
+    return client.com.atproto.repo.list_records(params)
+
+
+@_network_retry
+def _delete_record(client: Client, did: str, collection: str, rkey: str):
+    """One deletion via com.atproto.repo.deleteRecord."""
+    return client.com.atproto.repo.delete_record(
+        models.ComAtprotoRepoDeleteRecord.Data(
+            repo=did,
+            collection=collection,
+            rkey=rkey,
+        )
+    )
+
+
+# ─── Record helpers ──────────────────────────────────────────────────────────
+def _parse_created_at(value) -> Optional[datetime]:
+    """Return UTC-aware datetime from a record value's createdAt field."""
+    raw: Optional[str] = None
+    if hasattr(value, "created_at"):
+        raw = value.created_at
+    elif isinstance(value, dict):
+        raw = value.get("createdAt") or value.get("created_at")
+    if not raw:
+        return None
+    try:
+        dt = dateutil_parser.isoparse(raw)
+        return dt.astimezone(timezone.utc) if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+def _is_reply(value) -> bool:
+    if hasattr(value, "reply"):
+        return value.reply is not None
+    if isinstance(value, dict):
+        return value.get("reply") is not None
+    return False
+
+
+def _record_text(value) -> str:
+    if hasattr(value, "text"):
+        return value.text or ""
+    if isinstance(value, dict):
+        return value.get("text", "") or ""
+    return ""
+
+
+# ─── Core logic ──────────────────────────────────────────────────────────────
+def process_posts(
+    *,
+    handle: str,
+    token: str,
+    pds_url: str,
+    days_old: int,
+    preview_only: bool,
+    log_file: Optional[str],
+    match_patterns: Tuple[str, ...],
+    use_regex: bool,
+    after: Optional[str],
+    before: Optional[str],
+    backup_file: Optional[str],
+    include_replies: bool,
+    include_reposts: bool,
+    delete_delay: float,
+    quiet: bool,
+) -> dict:
+    client = Client(base_url=pds_url)
     try:
         client.login(handle, token)
     except Exception as e:
         logger.error("Login failed: %s", e)
-        return {"scanned": 0, "matched": 0, "deleted": 0, "failed": 0}
+        sys.exit(2)
+
+    did: str = client.me.did
+    logger.info("Authenticated  handle=%s  DID=%s  PDS=%s", handle, did, pds_url)
+
     cutoff = datetime.now(timezone.utc) - timedelta(days=days_old)
+    after_dt = dateutil_parser.parse(after).astimezone(timezone.utc) if after else None
+    before_dt = dateutil_parser.parse(before).astimezone(timezone.utc) if before else None
 
-    # Parse after/before if provided
-    after_dt = parser.parse(after).astimezone(timezone.utc) if after else None
-    before_dt = parser.parse(before).astimezone(timezone.utc) if before else None
+    compiled: list = (
+        [re.compile(p, re.IGNORECASE) for p in match_patterns]
+        if use_regex and match_patterns
+        else list(match_patterns)
+    )
 
-    posts = []
-    cursor = None
+    # posts first, then native reposts if requested
+    collections = ["app.bsky.feed.post"]
+    if include_reposts:
+        collections.append("app.bsky.feed.repost")
 
-    # Prepare matchers
-    compiled_patterns = []
-    if match_patterns:
-        if use_regex:
-            compiled_patterns = [re.compile(p, re.IGNORECASE) for p in match_patterns]
-        else:
-            compiled_patterns = match_patterns
+    # (uri, collection, rkey, created_at, text)
+    candidates: List[Tuple[str, str, str, datetime, str]] = []
+    total_scanned = 0
 
-    if not quiet:
-        logger.info(f"Scanning posts older than {days_old} days…")
+    for collection in collections:
+        cursor: Optional[str] = None
+        label = collection.rsplit(".", 1)[-1]
 
-    # Hide fetching pages progress bar in quiet mode
-    page_bar_args = {"desc": "Fetching pages", "unit": "page"}
-    # Remove disabling in quiet mode
-    # if quiet:
-    #     page_bar_args["disable"] = True
-
-    with tqdm(**page_bar_args) as page_bar:
-        while True:
-            feed = fetch_feed_page(client, handle, cursor, limit=50)
-            for item in feed.feed:
-                pt = parser.isoparse(item.post.indexed_at)
-                try:
-                    pt = pt.astimezone(timezone.utc)
-                except Exception:
-                    pt = pt.replace(tzinfo=timezone.utc)
-                # Change .dict() to .model_dump()
-                record_dict = item.post.record.model_dump()
-                text = record_dict.get("text", "")
-
-                # Filter by cutoff, date range, and match patterns
-                if pt < cutoff:
-                    # Replies: check if 'reply' field exists and is not None
-                    is_reply = getattr(item.post, "reply", None) is not None
-                    # Reposts: check if 'embed' field is a repost (type 'app.bsky.embed.record#view')
-                    embed = getattr(item.post, "embed", None)
-                    is_repost = False
-                    if embed and hasattr(embed, "$type"):
-                        is_repost = embed.type == "app.bsky.embed.record#view"
-                    elif embed and isinstance(embed, dict):
-                        is_repost = embed.get("$type") == "app.bsky.embed.record#view"
-
-                    # Exclude replies/reposts if not included
-                    if (is_reply and not include_replies) or (is_repost and not include_reposts):
+        with tqdm(desc=f"Scanning {label}s", unit=" page", disable=quiet) as pbar:
+            while True:
+                page = _list_records(client, did, collection, cursor)
+                for rec in page.records:
+                    total_scanned += 1
+                    created_at = _parse_created_at(rec.value)
+                    if created_at is None:
+                        logger.debug("Skipping %s — no createdAt", rec.uri)
+                        continue
+                    if created_at >= cutoff:
+                        continue
+                    if after_dt and created_at < after_dt:
+                        continue
+                    if before_dt and created_at > before_dt:
                         continue
 
-                    in_range = True
-                    if after_dt and pt < after_dt:
-                        in_range = False
-                    if before_dt and pt > before_dt:
-                        in_range = False
-                    matched = True
-                    if compiled_patterns:
+                    text = ""
+                    if collection == "app.bsky.feed.post":
+                        if not include_replies and _is_reply(rec.value):
+                            continue
+                        text = _record_text(rec.value)
+
+                    if compiled:
                         if use_regex:
-                            matched = any(p.search(text) for p in compiled_patterns)
+                            if not any(p.search(text) for p in compiled):
+                                continue
                         else:
-                            matched = any(p.lower() in text.lower() for p in compiled_patterns)
-                    if in_range and matched:
-                        posts.append((item.post.uri, item.post, pt))
-            cursor = feed.cursor
-            page_bar.update()
-            if not cursor:
-                break
+                            tl = text.lower()
+                            if not any(p.lower() in tl for p in compiled):
+                                continue
 
-    total = len(posts)
-    if not total:
-        logger.info("✅ No posts to delete/preview.")
-        return {"scanned": page_bar.n * 50, "matched": 0, "deleted": 0, "failed": 0}
+                    rkey = rec.uri.split("/")[-1]
+                    candidates.append((rec.uri, collection, rkey, created_at, text))
 
-    # Decide where to log
-    if not log_file:
-        log_file = "preview_log.txt" if preview_only else "deleted_posts_log.txt"
-    logger.info(f"Writing details to {log_file}")
+                pbar.update()
+                cursor = page.cursor
+                if not cursor:
+                    break
 
-    # Decide backup file
-    if not backup_file:
-        backup_file = "deleted_posts_backup.jsonl"
+        logger.info("Scanned %d %s record(s)", total_scanned, label)
+
+    if not candidates:
+        logger.info("No posts match the given criteria.")
+        return {"scanned": total_scanned, "matched": 0, "deleted": 0, "failed": 0}
+
+    log_file = log_file or ("preview_log.txt" if preview_only else "deleted_posts_log.txt")
+    backup_file = backup_file or "deleted_posts_backup.jsonl"
+    logger.info("Writing log to %s", log_file)
 
     deleted = failed = 0
     backup_fh = None
@@ -157,148 +213,217 @@ def process_posts(
         if not preview_only:
             backup_fh = open(backup_file, "a", encoding="utf-8")
 
-        # Only show the main progress bar if not quiet, otherwise disable it
-        post_bar_args = {"desc": "Processing posts", "unit": "post"}
-        # Remove disabling in quiet mode
-        # if quiet:
-        #     post_bar_args["disable"] = True  # Show progress bar even in quiet mode
-
-        with open(log_file, "a", encoding="utf-8") as f, \
-             tqdm(posts, **post_bar_args) as post_bar:
-            for uri, post, pt in post_bar:
-                # Change .dict() to .model_dump()
-                record_dict = post.record.model_dump()
-                text = record_dict.get("text", "")
-                text = text.replace("\n", " ")
-                f.write(f"{pt.strftime('%Y-%m-%d %H:%M:%S')} UTC  {text}\n---\n")
+        with open(log_file, "a", encoding="utf-8") as log_fh, tqdm(
+            candidates, desc="Processing", unit=" post", disable=quiet
+        ) as bar:
+            for uri, collection, rkey, created_at, text in bar:
+                log_fh.write(
+                    f"{created_at.strftime('%Y-%m-%d %H:%M:%S')} UTC  "
+                    f"{text.replace(chr(10), ' ')}\n---\n"
+                )
                 if not preview_only:
-                    # Backup full post JSON before deletion
-                    backup_fh.write(json.dumps({
-                        "uri": uri,
-                        "datetime": pt.isoformat(),
-                        # Change .dict() to .model_dump()
-                        "post": post.model_dump()
-                    }, ensure_ascii=False) + "\n")
+                    if backup_fh:
+                        backup_fh.write(
+                            json.dumps(
+                                {
+                                    "uri": uri,
+                                    "collection": collection,
+                                    "rkey": rkey,
+                                    "created_at": created_at.isoformat(),
+                                    "text": text,
+                                },
+                                ensure_ascii=False,
+                            )
+                            + "\n"
+                        )
                     try:
-                        delete_record(client, handle, uri)
+                        _delete_record(client, did, collection, rkey)
                         deleted += 1
+                        time.sleep(delete_delay)
                     except Exception as e:
-                        logger.warning(f"Failed deleting {uri}: {e}")
+                        logger.warning("Failed to delete %s: %s", uri, e)
                         failed += 1
-                post_bar.update()
     finally:
         if backup_fh:
             backup_fh.close()
 
     return {
-        "scanned": page_bar.n * 50,
-        "matched": total,
+        "scanned": total_scanned,
+        "matched": len(candidates),
         "deleted": deleted,
-        "failed": failed
+        "failed": failed,
     }
 
-# ─── CLI ENTRYPOINT ────────────────────────────────────────────────────────────
-@click.command(
-    help="Delete or preview BlueSky posts older than N days.\n\n"
-         "SECURITY TIP: For automation, consider passing your app password via the BYESKY_TOKEN environment variable instead of the --token argument."
-)
-@click.version_option(__version__, "--version", message="ByeSky version %(version)s")
-@click.option("--handle", "-u", prompt="BlueSky handle", help="e.g. yourname.bsky.social")
-@click.option("--token", "-p", default=None, help="App password (16-char); will prompt if missing")
-@click.option("--days", "-d", default=30, show_default=True,
-              help="Delete posts older than this many days")
-@click.option("--preview/--no-preview", default=True,
-              help="Only show what would be deleted without actually deleting")
-@click.option("--log-file", "-l", default=None,
-              help="Override log file name (defaults to preview_log.txt or deleted_posts_log.txt)")
-@click.option("--match", "-m", multiple=True, help="Only delete posts containing this keyword or matching regex (can be used multiple times)")
-@click.option("--regex/--no-regex", default=False, help="Interpret --match patterns as regex")
-@click.option("--after", default=None, help="Only consider posts after this date (YYYY-MM-DD or ISO format)")
-@click.option("--before", default=None, help="Only consider posts before this date (YYYY-MM-DD or ISO format)")
-@click.option("--backup-file", default=None, help="Backup deleted posts to this JSONL file (default: deleted_posts_backup.jsonl)")
-@click.option("--include-replies/--exclude-replies", default=False, help="Include replies (default: exclude)")
-@click.option("--include-reposts/--exclude-reposts", default=False, help="Include reposts (default: exclude)")
-@click.option("--verbose", is_flag=True, default=False, help="Enable verbose output (DEBUG logging)")
-@click.option("--quiet", is_flag=True, default=False, help="Suppress most output except errors")
-def cli(handle, token, days, preview, log_file, match, regex, after, before, backup_file, include_replies, include_reposts, verbose, quiet):
-    # Set logging level based on flags
-    if quiet:
-        logger.setLevel(logging.ERROR)
-    elif verbose:
-        logger.setLevel(logging.DEBUG)
-    else:
-        logger.setLevel(logging.INFO)
 
-    # Prevent accidental deletion with low --days
+# ─── CLI ─────────────────────────────────────────────────────────────────────
+@click.command(
+    help=(
+        "Delete or preview AT Protocol / Bluesky posts older than N days.\n\n"
+        "Supports Bluesky (bsky.social) and self-hosted PDS instances via --pds.\n\n"
+        "SECURITY: Pass your app password via the BYESKY_TOKEN environment variable "
+        "rather than --token to avoid exposing it in your process list."
+    )
+)
+@click.version_option(__version__, "--version", message="%(prog)s %(version)s")
+@click.option(
+    "--handle", "-u",
+    prompt="Bluesky handle",
+    help="Your handle, e.g. alice.bsky.social or alice.example.com",
+)
+@click.option(
+    "--token", "-p",
+    default=None,
+    envvar="BYESKY_TOKEN",
+    help="App password; falls back to BYESKY_TOKEN env var, then interactive prompt",
+)
+@click.option(
+    "--pds",
+    default=BSKY_PDS,
+    show_default=True,
+    help="AT Protocol PDS base URL (set to your PDS for self-hosted instances)",
+)
+@click.option(
+    "--days", "-d",
+    default=30,
+    show_default=True,
+    help="Target posts older than this many days",
+)
+@click.option(
+    "--preview/--no-preview",
+    default=True,
+    help="Dry run — show what would be deleted without deleting (default: --preview)",
+)
+@click.option(
+    "--log-file", "-l",
+    default=None,
+    help="Log filename (default: preview_log.txt or deleted_posts_log.txt)",
+)
+@click.option(
+    "--match", "-m",
+    multiple=True,
+    help="Only target posts containing this keyword; may be repeated",
+)
+@click.option(
+    "--regex/--no-regex",
+    default=False,
+    help="Treat --match values as regular expressions",
+)
+@click.option(
+    "--after",
+    default=None,
+    metavar="DATE",
+    help="Only target posts on or after this date (YYYY-MM-DD or ISO 8601)",
+)
+@click.option(
+    "--before",
+    default=None,
+    metavar="DATE",
+    help="Only target posts on or before this date (YYYY-MM-DD or ISO 8601)",
+)
+@click.option(
+    "--backup-file",
+    default=None,
+    help="JSONL file for deleted-post backups (default: deleted_posts_backup.jsonl)",
+)
+@click.option(
+    "--include-replies/--exclude-replies",
+    default=False,
+    help="Include reply posts (default: exclude)",
+)
+@click.option(
+    "--include-reposts/--exclude-reposts",
+    default=False,
+    help="Include native reposts (app.bsky.feed.repost records; default: exclude)",
+)
+@click.option(
+    "--delete-delay",
+    default=DELETE_DELAY,
+    show_default=True,
+    type=float,
+    help="Seconds between deletions (rate-limit buffer)",
+)
+@click.option("--verbose", is_flag=True, default=False, help="Enable DEBUG logging")
+@click.option("--quiet", is_flag=True, default=False, help="Suppress all output except errors and the summary")
+def cli(
+    handle, token, pds, days, preview, log_file, match, regex,
+    after, before, backup_file, include_replies, include_reposts,
+    delete_delay, verbose, quiet,
+):
+    level = logging.ERROR if quiet else (logging.DEBUG if verbose else logging.INFO)
+    logger.setLevel(level)
+    for lib in ("atproto_client", "httpx"):
+        logging.getLogger(lib).setLevel(logging.DEBUG if verbose else logging.WARNING)
+
     if not preview and days < 1:
-        logger.error("Refusing to delete posts newer than 1 day. Use --days 1 or higher.")
+        logger.error("Refusing to target posts newer than 1 day. Use --days 1 or higher.")
         sys.exit(2)
 
-    # Control atproto_client HTTP request logs
-    atproto_logger = logging.getLogger("atproto_client")
-    httpx_logger = logging.getLogger("httpx")
-    if quiet:
-        atproto_logger.setLevel(logging.ERROR)
-        httpx_logger.setLevel(logging.ERROR)
-    elif verbose:
-        atproto_logger.setLevel(logging.DEBUG)
-        httpx_logger.setLevel(logging.DEBUG)
-    else:
-        atproto_logger.setLevel(logging.WARNING)
-        httpx_logger.setLevel(logging.WARNING)
+    # Normalise PDS URL
+    pds = pds.rstrip("/")
+    if "://" not in pds:
+        pds = f"https://{pds}"
 
-    # Warn if token is passed via command line (visible in process list)
     if token and "BYESKY_TOKEN" not in os.environ:
-        logger.warning("SECURITY: Passing the app password via --token exposes it in your process list. "
-                       "For automation, set the BYESKY_TOKEN environment variable instead.")
+        logger.warning(
+            "SECURITY: --token exposes your password in the process list. "
+            "Use the BYESKY_TOKEN environment variable for automation."
+        )
 
-    # Mask token in logs (never print token)
-    token_masked = "*" * len(token) if token else None
-    logger.info(f"Using handle: {handle}, token: {token_masked}, days: {days}, preview: {preview}")
-
-    # Prefer environment variable for token if available
-    if not token:
-        token = os.environ.get("BYESKY_TOKEN")
     if not token:
         token = getpass.getpass("App password: ").strip()
 
-    # Confirm deletion unless preview or quiet
+    if not quiet:
+        logger.info(
+            "handle=%s  pds=%s  days=%d  preview=%s",
+            handle, pds, days, preview,
+        )
+
     if not preview and not quiet:
         click.confirm(
-            f"Are you sure you want to DELETE posts older than {days} days? This cannot be undone.",
-            abort=True
+            f"Delete posts older than {days} days from {handle}? This cannot be undone.",
+            abort=True,
         )
 
     try:
         result = process_posts(
-            handle, token, days, preview, log_file,
-            match_patterns=match, use_regex=regex,
-            after=after, before=before,
+            handle=handle,
+            token=token,
+            pds_url=pds,
+            days_old=days,
+            preview_only=preview,
+            log_file=log_file,
+            match_patterns=match,
+            use_regex=regex,
+            after=after,
+            before=before,
             backup_file=backup_file,
             include_replies=include_replies,
             include_reposts=include_reposts,
-            quiet=quiet
+            delete_delay=delete_delay,
+            quiet=quiet,
         )
     except (OSError, IOError) as e:
-        logger.error(f"File error: {e}")
+        logger.error("File error: %s", e)
         sys.exit(3)
+    except SystemExit:
+        raise
     except Exception as e:
-        logger.error(f"Unexpected error: {e}")
+        logger.error("Unexpected error: %s", e)
         sys.exit(99)
 
-    # Always show summary, even in quiet mode
-    click.echo("\n── Summary ──────────────────────────")
-    click.echo(f" Posts scanned   : {result['scanned']}")
-    click.echo(f" Posts matched   : {result['matched']}")
+    effective_log = log_file or ("preview_log.txt" if preview else "deleted_posts_log.txt")
+    click.echo("\n── Summary ───────────────────────────────")
+    click.echo(f"  Posts scanned   : {result['scanned']}")
+    click.echo(f"  Posts matched   : {result['matched']}")
     if not preview:
-        click.echo(f" Posts deleted   : {result['deleted']}")
-        click.echo(f" Delete failures : {result['failed']}")
-    # Mask password in summary/log output
-    click.echo(f" Log file        : {log_file or ('preview_log.txt' if preview else 'deleted_posts_log.txt')}")
-    click.echo("──────────────────────────────────────")
+        click.echo(f"  Posts deleted   : {result['deleted']}")
+        click.echo(f"  Delete failures : {result['failed']}")
+    click.echo(f"  Log file        : {effective_log}")
+    click.echo("──────────────────────────────────────────")
 
-    if result["failed"] > 0:
+    if result.get("failed", 0) > 0:
         sys.exit(1)
+
 
 if __name__ == "__main__":
     cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-atproto
-click
-tqdm
-tenacity
-python-dateutil
+atproto>=0.0.50
+click>=8.0
+tqdm>=4.0
+tenacity>=8.0
+python-dateutil>=2.8
 pydantic>=2.0


### PR DESCRIPTION
## Summary

- Replace `app.bsky.feed.getAuthorFeed` with `com.atproto.repo.listRecords` — removes AppView dependency, works on any AT Protocol PDS
- Use DID instead of handle for all repo operations (spec-correct)
- Add `--pds` flag for self-hosted PDS instances (defaults to `https://bsky.social`)
- Fix repost detection: scan `app.bsky.feed.repost` collection separately
- Fix reply detection: check `reply` field on raw record values
- Add `--delete-delay` (default 0.5s) between deletions to respect rate limits
- Improve retry: 5 attempts with 2–60s exponential back-off
- Fix scan count: per-record counter instead of `page_count * 50`
- Windows-safe root check (`os.geteuid()` guarded by `os.name != "nt"`)
- Update README: changelog, self-hosted PDS guide, PDS URL lookup steps, zsh quoting tip

## Test plan

- [x] Basic preview scan (`--preview`) against bsky.social
- [x] `--include-replies` and `--include-reposts`
- [x] `--after` / `--before` date range filtering
- [x] `--match` keyword and `--regex` filtering
- [x] `--quiet` mode (only summary printed)
- [x] `--days 0 --no-preview` safety guard (exits 2)
- [x] `--version` flag
- [x] Self-hosted PDS (`--pds "https://blacksky.app"`) with custom domain handle
- [x] Security review — no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the core listing/deletion flow to new AT Protocol endpoints and adds cross-server (custom PDS) support, which can affect what records are selected and deleted. Safeguards are present (`--preview`, `--days` minimum, backups), but correctness of filtering and rate-limiting is critical.
> 
> **Overview**
> ByeSky now operates **directly against a PDS** using `com.atproto.repo.listRecords`/`deleteRecord` and DID-based repo identifiers, removing reliance on the AppView feed API and enabling `--pds` for self-hosted servers.
> 
> The deletion pipeline was reworked to scan records per-collection (including native reposts via `app.bsky.feed.repost`), improve reply/repost detection, and produce accurate scanned/matched counts; it also adds `--delete-delay` plus stronger retry/backoff and a Windows-safe root check.
> 
> Docs and packaging were updated for v0.2.0 (new flags, self-hosted PDS guidance, exit codes) and `requirements.txt` now pins minimum dependency versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 354d153a9150084489754bf598f4192bb77e76a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->